### PR TITLE
Add option to install rsync daemon

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -56,9 +56,9 @@ suites:
             gid: vagrant
             read only: "no"
             list: "yes"
-            auth users: vagrant, kitchen
-            secrets file: /etc/rsyncd.secrets
             hosts allow: 127.0.0.1/255.255.255.0
+            # auth users: vagrant, kitchen
+            # secrets file: /etc/rsyncd.secrets
         # Normally these vars would be in Ansible Vault
         rsync_daemon_user_secrets:
           vagrant: vagrant

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,7 +25,7 @@ platforms:
   #- name: ubuntu-10.04 # lucid
   #- name: ubuntu-12.04 # precise
   #- name: ubuntu-13.10 # saucy
-  #- name: ubuntu-14.04 # trusty
+  - name: ubuntu-14.04 # trusty
   # - name: ubuntu-14.10 # utopic ## No bento box yet... Official Scheduled Release: October 23rd 2014
   # - name: centos-5.10 # TODO: NOT TESTED YET... unsure if kitchen-ansible works yet...
   - name: centos-6.4

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,69 @@
+---
+driver:
+    name: vagrant
+
+provisioner:
+#  ansible_platform: ubuntu
+  name: ansible_playbook
+#  roles_path:
+  hosts: test-kitchen
+  require_ansible_omnibus: true
+  ansible_omnibus_url: http://10.0.2.2:8080/install_ansible.sh
+#  require_ansible_repo: true
+  require_ruby_for_busser: false
+  require_chef_for_busser: true
+#  ansible_check: true
+  ansible_diff: true
+  ansible_verbose: true
+  ansible_verbosity: 2
+  sudo: true
+  # playbook: default.yml
+  extra_vars:
+    rp_environment: dev
+
+platforms:
+  #- name: ubuntu-10.04 # lucid
+  #- name: ubuntu-12.04 # precise
+  #- name: ubuntu-13.10 # saucy
+  #- name: ubuntu-14.04 # trusty
+  # - name: ubuntu-14.10 # utopic ## No bento box yet... Official Scheduled Release: October 23rd 2014
+  # - name: centos-5.10 # TODO: NOT TESTED YET... unsure if kitchen-ansible works yet...
+  - name: centos-6.4
+  - name: centos-6.5
+  - name: centos-7.0
+  # - name: nocm_centos-6.5
+  #   driver_plugin: vagrant
+  #   driver_config:
+  #     box: nocm_centos-6.5
+  #     box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
+      # network:
+      #  - ['forwarded_port', {guest: 8080, host: 8080}]
+      #  - [ 'private_network', { ip: '192.168.33.11' } ]
+
+suites:
+  - name: default
+  - name: daemon
+    provisioner:
+      playbook: test/integration/daemon.yml
+      extra_vars:
+        # Vars for testing the role in test-kitchen
+        rsync_install_daemon: true
+        rsync_daemon_shares:
+          kitchen:
+            path: /tmp/kitchen/
+            comment: test-kitchen
+            uid: vagrant
+            gid: vagrant
+            read only: "no"
+            list: "yes"
+            auth users: vagrant, kitchen
+            secrets file: /etc/rsyncd.secrets
+            hosts allow: 127.0.0.1/255.255.255.0
+        # Normally these vars would be in Ansible Vault
+        rsync_daemon_user_secrets:
+          vagrant: vagrant
+          kitchen: kitchen
+# - name: my-suite
+#   provisioner:
+#     extra_vars:
+#       foo: bar

--- a/README.md
+++ b/README.md
@@ -3,17 +3,114 @@ rsync
 
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-kbrebanov.rsync-660198.svg)](https://galaxy.ansible.com/list#/roles/3303)
 
-Installs rsync.
+Installs rsync.  Optionally [as a daemon][1] with `/etc/rsyncd.conf` and `/etc/xinetd.d/rsync`.
 
 Requirements
 ------------
 
-This role requires Ansible 1.4 or higher.
+This role requires Ansible 1.9 or higher.
 
 Role Variables
 --------------
 
-None
+The default role variables in `defaults/main.yml` are:
+
+    ---
+    # defaults file for rsync
+    
+    rsync_install_daemon: false
+    
+    # Only install rsync by default, (xinetd daemon is only needed if rsync_install_daemon is set)
+    rsync_packages:
+      - rsync
+    
+    # Changing this to 'yes' will disable the rsync service, so you probably want to leave
+    # this alone...
+    rsync_disable: "no"
+    
+    # See rsync(1) man page for details on how to set the server arguments
+    # http://linux.die.net/man/1/rsync
+    rsync_server_args: "--daemon"
+    
+    # See xinetd.conf(5) man page for details on how to set the xinetd service arguments
+    # http://linux.die.net/man/5/xinetd.conf
+    rsync_log_on_failure: "USERID"
+    rsync_flags: IPv6
+    rsync_socket_type: stream
+    rsync_port: 873
+    rsync_protocol: tcp
+    rsync_wait: no
+    rsync_user: root
+    rsync_server: /usr/bin/rsync
+    
+    rsync_daemon_manage_config: true
+    rsync_daemon_lock_file: /var/run/rsync.lock
+    rsync_daemon_log_file: /var/log/rsyncd.log
+    rsync_daemon_pid_file: /var/run/rsyncd.pid
+
+
+  - `rsync_install_daemon` - Install [rsync in `--daemon` mode managed by xinetd][1].
+  - `rsync_disable` - Disables `xinetd` `rsync` daemon service (in `/etc/xinetd.d/rsync`).  Changing this to 'yes' will disable the `rsync` service.
+  - `rsync_daemon_manage_config` - Default `true` (Boolean).  Determines whether or not this Ansible role will manage the `/etc/rsyncd.conf` file via the provided template.  If this is `false`, you must provide your own `/etc/rsyncd.conf` file.
+  - `rsync_daemon_user_secrets` - A [Dict][5] (a.k.a: [Hash][6]) of `key: value` pairs in the form: `user: password`.  To avoid having to specify these vars in your playbook in plaintext, you may want to use [Ansible Vault][7].  These will be used as [`user:password` lines to write to `/etc/rsyncd.secrets`][4].  If set, the file `/etc/rsyncd.secrets` will be managed by the template provided in this role.  **Note**:  If `rsync_daemon_user_secrets` is set, the global `/etc/rsyncd.secrets` file will be used for **all** shares specified in `rsync_daemon_shares`, and all users specified will be used as the `auth users` parameter.  This role's behavior is set in this way so as to provide a minimum level of guaranteed security.  The format for this Dict / Hash is as follows (please use more secure passwords!):
+
+        rsync_daemon_user_secrets:
+          myuser: mypassword
+          myuser2: mypassword2
+          vagrant: vagrant
+
+  - `rsync_daemon_shares` - A [Dict][5] (a.k.a: [Hash][6]) of folder shares ([`rsyncd.conf(5)`][4] man page calls these "`modules`").  These will be iterated over and placed in the `/etc/rsyncd.conf` file in the following format:
+
+        rsync_daemon_shares:
+          mymodule:
+            path: /tmp/somefolder/
+            comment: things to share as mymodule
+            uid: myuser
+            gid: mygroup
+            read only: "no"
+            list: "yes"
+            hosts allow: 127.0.0.1/255.255.255.0
+
+    - The format for the resulting rendered template would be (assuming users: `myuser`, `myuser2`, and `vagrant` were specified in `rsync_daemon_user_secrets`, and defaults for `rsync_daemon_lock_file`, `rsync_daemon_log_file`, and `rsync_daemon_pid_file`):
+
+          lock file = /var/run/rsync.lock
+          log file = /var/log/rsyncd.log
+          pid file = /var/run/rsyncd.pid
+
+          [mymodule]
+              comment = things to share as mymodule
+              uid = myuser
+              list = yes
+              hosts allow = 127.0.0.1/255.255.255.0
+              gid = mygroup
+              path = /tmp/somefolder/
+              read only = no
+              auth users = myuser, myuser2, vagrant
+              secrets file = /etc/rsyncd.secrets
+
+  - `rsync_daemon_max_connections` - [`max connections` rsyncd.conf parameter][4].  This parameter allows you to specify the maximum number of simultaneous connections you will allow. Any clients connecting when the maximum has been reached will receive a message telling them to try later. **The default is `0`**, which means no limit. A negative value disables the module. See also the `lock file` parameter.
+  - `rsync_daemon_lock_file` - [`lock file` rsyncd.conf parameter][4].  This parameter specifies the file to use to support the `max connections` parameter. The `rsync` daemon uses record locking on this file to ensure that the `max connections` limit is not exceeded for the modules sharing the lock file. **The default is `/var/run/rsync.lock`**.
+  - `rsync_daemon_log_file` - [`log file` rsyncd.conf parameter][4].  When the `log file` parameter is set to a non-empty string, the `rsync` daemon will log messages to the indicated file rather than using `syslog`.  If the daemon fails to open the specified file, it will fall back to
+using `syslog` and output an error about the failure.  **The default is `/var/log/rsyncd.log`**.
+  - `rsync_daemon_pid_file` - [`pid file` rsyncd.conf parameter][4].  This parameter tells the `rsync` daemon to write its process ID to that file. If the file already exists, the `rsync` daemon will abort rather than overwrite the file.  **The default is `/var/run/rsyncd.pid`**.
+  - `rsync_server_args` - Arguments to pass the rsync process that is spawned by `xinetd` as a daemon.  See [rsync(1) man page][2] for details on server args.
+  - `rsync_log_on_failure` - [`log_on_failure` xinetd.conf service argument][3] for `rsync` daemon.  Determines what information is logged.
+  - `rsync_flags` - [`flags` xinetd.conf service argument][3] for `rsync` daemon.  See xinetd.conf(5) man page for details on how to set this xinetd service attribute.
+  - `rsync_socket_type` - [`socket_type` xinetd.conf service argument][3] for `rsync` daemon.  Type of socket to use.  See xinetd.conf(5) man page for details on how to set this xinetd service attribute.
+  - `rsync_port` - [`port` xinetd.conf service argument][3] for `rsync` daemon.  Optional if service is defined in `/etc/services`.  Determines the service port. If this attribute is specified for a service listed in /etc/services, it must be equal to the port number listed in that file.
+  - `rsync_protocol` - [`protocol` xinetd.conf service argument][3] for `rsync` daemon.  Optional.  Determines the protocol that is employed by the service.  The protocol must exist in `/etc/protocols`. **If this attribute is not defined, the default protocol employed by the service will be used.**
+  - `rsync_wait` - [`wait` xinetd.conf service argument][3] for `rsync` daemon.  This attribute determines if the service is single-threaded or multi-threaded and whether or not xinetd accepts the connection or the server program accepts the connection. If its value is `yes`, the service is single-threaded; this means that `xinetd` will start the server and then it will stop handling requests for the service until the server dies and that the server software will accept the connection. If the attribute value is `no`, the service is multi-threaded and `xinetd` will keep handling new service requests and `xinetd` will accept the connection. It should be noted that `udp/dgram` services normally expect the value to be `yes` since `udp` is not connection oriented, while `tcp/stream` servers normally expect the value to be `no`.
+  - `rsync_user` - [`user` xinetd.conf service argument][3] for `rsync` daemon.  Determines the `uid` for the server process. The `user` attribute can either be numeric or a name. If a name is given (recommended), the user name must exist in `/etc/passwd`. This attribute is ineffective if the effective user ID of `xinetd` is not super-user.
+  - `rsync_server` - [`server` xinetd.conf service argument][3] for `rsync` daemon.  Determines the program to execute for this service.
+
+
+[1]: http://www.jveweb.net/en/archives/2011/01/running-rsync-as-a-daemon.html
+[2]: http://linux.die.net/man/1/rsync
+[3]: http://linux.die.net/man/5/xinetd.conf
+[4]: http://linux.die.net/man/5/rsyncd.conf
+[5]: http://docs.ansible.com/YAMLSyntax.html#yaml-basics
+[6]: https://en.wikipedia.org/?title=YAML#cite_note-Vartype000-4
+[7]: http://docs.ansible.com/playbooks_vault.html
 
 Dependencies
 ------------
@@ -23,11 +120,46 @@ None
 Example Playbook
 ----------------
 
-Install rsync
+Install `rsync` package without daemon:
+
 ```
 - hosts: all
   roles:
     - { role: kbrebanov.rsync }
+```
+
+Install `rsync` with `xinetd`-managed daemon:
+
+```
+---
+# This playbook deploys the rsync role with xinetd-managed daemon
+
+- hosts: my-host
+  user: root
+  vars:
+    rsync_install_daemon: true
+    # Enable these example folder shares (a.k.a: "modules")
+    rsync_daemon_shares:
+      kitchen:
+        path: /tmp/foo
+        comment: foo files
+        uid: vagrant
+        gid: vagrant
+        read only: "no"
+        list: "yes"
+        hosts allow: 127.0.0.1/255.255.255.0
+        # "auth users" are auto-generated by template from rsync_daemon_user_secrets
+        # auth users: vagrant, kitchen
+        # secrets file: /etc/rsyncd.secrets
+    # Normally these vars should be in Ansible Vault
+    # But for the purpose of this example they are shown.
+    # Define this as `user: password` pairs:
+    rsync_daemon_user_secrets:
+      vagrant: vagrant
+      kitchen: kitchen
+
+  roles:
+    - rsync
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -171,3 +171,5 @@ Author Information
 ------------------
 
 Kevin Brebanov
+
+James Cuzella ([@trinitronx](https://github.com/trinitronx))

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,32 @@
 ---
 # defaults file for rsync
+
+rsync_install_daemon: false
+
+# Only install rsync by default, (xinetd daemon is only needed if rsync_install_daemon is set)
+rsync_packages:
+  - rsync
+
+# Changing this to 'yes' will disable the rsync service, so you probably want to leave
+# this alone...
+rsync_disable: "no"
+
+# See rsync(1) man page for details on how to set the server arguments
+# http://linux.die.net/man/1/rsync
+rsync_server_args: "--daemon"
+
+# See xinetd.conf(5) man page for details on how to set the xinetd service arguments
+# http://linux.die.net/man/5/xinetd.conf
+rsync_log_on_failure: "USERID"
+rsync_flags: IPv6
+rsync_socket_type: stream
+rsync_port: 873
+rsync_protocol: tcp
+rsync_wait: no
+rsync_user: root
+rsync_server: /usr/bin/rsync
+
+rsync_daemon_manage_config: true
+rsync_daemon_lock_file: /var/run/rsync.lock
+rsync_daemon_log_file: /var/log/rsyncd.log
+rsync_daemon_pid_file: /var/run/rsyncd.pid

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,11 @@
 ---
 # handlers file for rsync
+- name: restart rsync
+  service:
+    name: "{{ rsync_service }}"
+    state: restarted
+
+- name: reload rsync
+  service:
+    name: "{{ rsync_service }}"
+    state: reloaded

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: BSD
-  min_ansible_version: 1.4
+  min_ansible_version: 1.9
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your
@@ -121,3 +121,4 @@ dependencies: []
   # dependencies available via galaxy should be listed here.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
+version: 1.0.0

--- a/tasks/apt_packages.yml
+++ b/tasks/apt_packages.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for rsync (Ubuntu specific)
+# tasks file for installing rsync on apt based distros
 
 - name: Install rsync packages
   apt: name={{ item }} state=present update_cache=yes cache_valid_time=3600

--- a/tasks/daemon-xinetd.yml
+++ b/tasks/daemon-xinetd.yml
@@ -1,0 +1,49 @@
+---
+# tasks file for rsync xinetd daemon
+
+- name: Install rsync daemon xinetd config
+  template: >
+    dest=/etc/xinetd.d/rsync
+    src=rsync-daemon-xinetd.j2
+    owner=root
+    group=root
+    mode=0644
+  notify: reload rsync
+  tags:
+    - rsync
+    - rsync_daemon
+
+- name: Install rsyncd.conf
+  template: >
+    dest=/etc/rsyncd.conf
+    src=rsyncd.conf.j2
+    owner=root
+    group=root
+    mode=0644
+  when: rsync_daemon_manage_config
+  notify: restart rsync
+  tags:
+    - rsync
+    - rsync_daemon
+
+- name: Install /etc/rsyncd.secrets
+  template: >
+    dest=/etc/rsyncd.secrets
+    src=rsyncd.secrets.j2
+    owner=root
+    group=root
+    mode=0600
+  when: rsync_daemon_user_secrets is defined
+  notify: restart rsync
+  tags:
+    - rsync
+    - rsync_daemon
+
+- name: Ensure service is started
+  service:
+    name: "{{ rsync_service }}"
+    state: started
+    enabled: true
+  tags:
+    - rsync
+    - rsync_daemon

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,10 @@
   include_vars: "{{ ansible_distribution }}.yml"
   tags: rsync
 
-- include: CentOS.yml
-  when: ansible_distribution == "CentOS"
-  tags: rsync
 
-- include: Ubuntu.yml
-  when: ansible_distribution == "Ubuntu"
+- include: apt_package.yml
+  when: ansible_pkg_mgr == 'apt'
+  tags: rsync
+- include: yum_package.yml
+  when: ansible_pkg_mgr == 'yum'
   tags: rsync

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,9 @@
   tags: rsync
 
 
-- include: apt_package.yml
+- include: apt_packages.yml
   when: ansible_pkg_mgr == 'apt'
   tags: rsync
-- include: yum_package.yml
+- include: yum_packages.yml
   when: ansible_pkg_mgr == 'yum'
   tags: rsync

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,12 @@
   include_vars: "{{ ansible_distribution }}.yml"
   tags: rsync
 
+- name: Include daemon-xinetd vars
+  include_vars: "daemon-xinetd.yml"
+  when: rsync_install_daemon
+  tags:
+    - rsync
+    - rsync_daemon
 
 - include: apt_packages.yml
   when: ansible_pkg_mgr == 'apt'
@@ -12,3 +18,9 @@
 - include: yum_packages.yml
   when: ansible_pkg_mgr == 'yum'
   tags: rsync
+
+- include: daemon-xinetd.yml
+  when: rsync_install_daemon
+  tags:
+    - rsync
+    - rsync_daemon

--- a/tasks/yum_packages.yml
+++ b/tasks/yum_packages.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for rsync (CentOS specific)
+# tasks file for installing rsync on yum based distros
 
 - name: Install rsync packages
   yum: name={{ item }} state=present

--- a/templates/rsync-daemon-xinetd.j2
+++ b/templates/rsync-daemon-xinetd.j2
@@ -1,0 +1,16 @@
+#jinja2:trim_blocks: False
+# rsync daemon configuration
+# {{ ansible_managed }}
+ service rsync
+ {
+         disable = {% if rsync_disable is string and rsync_disable | match("^(no|yes)$") %}{{ rsync_disable }}{% else %}{{ rsync_disable | ternary('yes','no') }}{% endif %}
+ flags           = {{ rsync_flags }}
+ socket_type     = {{ rsync_socket_type }}
+ port            = {{ rsync_port }}
+ protocol        = {{ rsync_protocol }}
+ wait            = {% if rsync_wait is string and rsync_wait | match("^(no|yes)$") %}{{ rsync_wait }}{% else %}{{ rsync_wait | ternary('yes','no') }}{% endif %}
+ user            = {{ rsync_user }}
+ server          = {{ rsync_server }}
+ server_args     = {{ rsync_server_args }}
+ log_on_failure  += {{ rsync_log_on_failure }}
+ }

--- a/templates/rsync-daemon-xinetd.j2
+++ b/templates/rsync-daemon-xinetd.j2
@@ -6,8 +6,8 @@
          disable = {% if rsync_disable is string and rsync_disable | match("^(no|yes)$") %}{{ rsync_disable }}{% else %}{{ rsync_disable | ternary('yes','no') }}{% endif %}
  flags           = {{ rsync_flags }}
  socket_type     = {{ rsync_socket_type }}
- port            = {{ rsync_port }}
- protocol        = {{ rsync_protocol }}
+{% if rsync_port is defined %} port            = {{ rsync_port }}{% endif %}
+{% if rsync_protocol is defined %} protocol        = {{ rsync_protocol }}{% endif %}
  wait            = {% if rsync_wait is string and rsync_wait | match("^(no|yes)$") %}{{ rsync_wait }}{% else %}{{ rsync_wait | ternary('yes','no') }}{% endif %}
  user            = {{ rsync_user }}
  server          = {{ rsync_server }}

--- a/templates/rsyncd.conf.j2
+++ b/templates/rsyncd.conf.j2
@@ -1,3 +1,4 @@
+{% if rsync_daemon_max_connections is defined and rsync_daemon_max_connections is number %}max connections = {{ rsync_daemon_max_connections | int }}{% endif %}
 lock file = {{ rsync_daemon_lock_file }}
 log file = {{ rsync_daemon_log_file }}
 pid file = {{ rsync_daemon_pid_file }}

--- a/templates/rsyncd.conf.j2
+++ b/templates/rsyncd.conf.j2
@@ -9,5 +9,7 @@ pid file = {{ rsync_daemon_pid_file }}
 {%     for (key, value) in share_settings.iteritems() %}
     {{ key }} = {{ value }}
 {%     endfor %}
+    auth users = {{ rsync_daemon_user_secrets.keys() | join(', ') }}
+    secrets file = /etc/rsyncd.secrets
 {%   endfor %}
 {% endif %}

--- a/templates/rsyncd.conf.j2
+++ b/templates/rsyncd.conf.j2
@@ -1,0 +1,12 @@
+lock file = {{ rsync_daemon_lock_file }}
+log file = {{ rsync_daemon_log_file }}
+pid file = {{ rsync_daemon_pid_file }}
+
+{% if rsync_daemon_shares is defined %}
+{%   for (share, share_settings) in rsync_daemon_shares.iteritems() %}
+[{{ share }}]
+{%     for (key, value) in share_settings.iteritems() %}
+    {{ key }} = {{ value }}
+{%     endfor %}
+{%   endfor %}
+{% endif %}

--- a/templates/rsyncd.secrets.j2
+++ b/templates/rsyncd.secrets.j2
@@ -1,0 +1,5 @@
+{% if rsync_daemon_user_secrets is defined %}
+{%   for (user, pass) in rsync_daemon_user_secrets.iteritems() %}
+{{ user }}:{{ pass }}
+{%   endfor %}
+{% endif %}

--- a/test/integration/daemon.yml
+++ b/test/integration/daemon.yml
@@ -1,0 +1,8 @@
+---
+# This playbook deploys the rsync role for testing
+
+- hosts: test-kitchen
+  user: root
+
+  roles:
+    - rsync

--- a/test/integration/daemon/serverspec/rsync_daemon_spec.rb
+++ b/test/integration/daemon/serverspec/rsync_daemon_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+# rsync and xinetd packages should be installed
+[ 'rsync', 'xinetd' ].each do |installed_package|
+  describe package( installed_package ) do
+    it { should be_installed }
+  end
+end
+
+describe file( '/etc/xinetd.d/rsync' ) do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  its(:content) { should match /^\s*service\s+rsync$/ }
+  its(:content) { should match /^\s*disable\s+=\s+no\s*$/ }
+  its(:content) { should match /^\s*wait\s+=\s+no\s*$/ }
+  its(:content) { should match /^\s*server\s+=\s+(.*)\/bin\/rsync\s*$/ }
+  its(:content) { should match /^\s*server_args\s+=\s+--daemon\s*$/ }
+  its(:content) { should match /^\s*socket_type\s+=\s+stream\s*$/ }
+  its(:content) { should match /^\s*port\s+=\s+873\s*$/ }
+  its(:content) { should match /^\s*protocol\s+=\s+tcp\s*$/ }
+end
+
+describe file( '/etc/rsyncd.conf' ) do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  its(:content) { should match /^\s*lock file\s+=\s+\/var\/run\/rsync\.lock/ }
+  its(:content) { should match /^\s*log file\s+=\s+\/var\/log\/rsyncd\.log/ }
+  its(:content) { should match /^\s*pid file\s+=\s+\/var\/run\/rsyncd\.pid/ }
+  its(:content) { should match /^\s*\[kitchen\]/ }
+  its(:content) { should match /^\s*path\s+=\s+\/tmp\/kitchen\// }
+  its(:content) { should match /^\s*comment\s+=\s+test-kitchen/ }
+  its(:content) { should match /^\s*uid\s+=\s+vagrant/ }
+  its(:content) { should match /^\s*gid\s+=\s+vagrant/ }
+  its(:content) { should match /^\s*read only\s+=\s+no/ }
+  its(:content) { should match /^\s*list\s+=\s+yes/ }
+  its(:content) { should match /^\s*auth users\s+=\s+vagrant,\s+kitchen/ }
+  its(:content) { should match /^\s*secrets file\s+=\s+\/etc\/rsyncd\.secrets/ }
+  its(:content) { should match /^\s*hosts allow\s+=\s+127\.0\.0\.1\/255\.255\.255\.0/ }
+end
+
+describe file( '/etc/rsyncd.secrets' ) do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 600 }
+  its(:content) { should match /^\s*vagrant:vagrant$/ }
+  its(:content) { should match /^\s*kitchen:kitchen$/ }
+end
+
+describe service( 'xinetd' ) do
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/integration/default.yml
+++ b/test/integration/default.yml
@@ -1,0 +1,9 @@
+---
+# This playbook deploys the rsync role for testing
+
+- hosts: test-kitchen
+  user: vagrant
+  sudo: true
+
+  roles:
+    - rsync

--- a/test/integration/default/serverspec/rsync_spec.rb
+++ b/test/integration/default/serverspec/rsync_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+# rsync package should be installed
+describe package( 'rsync' ) do
+  it { should be_installed }
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+
+set :backend, :exec
+
+# Serverspec v2
+# include Serverspec::Helper::DetectOS
+# include Serverspec::Helper::Exec
+
+# RSpec.configure do |c|
+#   c.before :all do
+#     c.os = backend(Serverspec::Commands::Base).check_os
+#   end
+# end

--- a/test/integration/sentinel-file
+++ b/test/integration/sentinel-file
@@ -1,0 +1,3 @@
+# This file is for validating that the xinetd rsync service works
+# It should be placed in /tmp/kitchen by kitchen-ansible,
+# and should be served by the share defined in /etc/rsyncd.conf

--- a/vars/daemon-xinetd.yml
+++ b/vars/daemon-xinetd.yml
@@ -1,0 +1,8 @@
+---
+# vars file for rsync xinetd daemon
+
+rsync_service: xinetd
+
+rsync_packages:
+  - xinetd
+  - rsync


### PR DESCRIPTION
Made a bunch of improvements:
- Abstract package installation to be package-manager specific rather than distro-specific
- Added serverspec tests using [`test-kitchen`](https://github.com/test-kitchen/test-kitchen) + [`kitchen-ansible`](https://github.com/neillturner/kitchen-ansible)
  - Test Suite for 'default' rsync role (when `rsync_install_daemon == false`)
  - Test Suite for 'daemon' rsync role (when `rsync_install_daemon == true`)
- Added [xinetd-managed rsync daemon](http://www.jveweb.net/en/archives/2011/01/running-rsync-as-a-daemon.html)

New [README.md](https://github.com/trinitronx/ansible-rsync/blob/b1b4ca1858c18f5d7828ce818eaec243730926d2/README.md) documents the new feature & vars.
